### PR TITLE
Fix Matplotlib errors in visualize.py

### DIFF
--- a/visualizationTools/visualize.py
+++ b/visualizationTools/visualize.py
@@ -208,7 +208,7 @@ if dpts.shape[0] > 0:
 
 """ Plot styling options """
 
-fontname='Arial'
+fontname='DejaVu Sans'
 
 # make the plot aspect ratio at most 4
 max_dim = max(lims[1]-lims[0])
@@ -237,7 +237,7 @@ ax.set_xlim3d(xmin,xmax_plot_range)
 ax.set_ylim3d(ymin,ymax_plot_range)
 ax.set_zlim3d(zmin,zmax_plot_range)
 
-ax.set_aspect('equal')
+# ax.set_aspect('equal')
 
 ax.grid(False)
 

--- a/visualizationTools/visualize.py
+++ b/visualizationTools/visualize.py
@@ -237,8 +237,6 @@ ax.set_xlim3d(xmin,xmax_plot_range)
 ax.set_ylim3d(ymin,ymax_plot_range)
 ax.set_zlim3d(zmin,zmax_plot_range)
 
-# ax.set_aspect('equal')
-
 ax.grid(False)
 
 ax.xaxis.pane.set_edgecolor('black')


### PR DESCRIPTION
Fixes fatal Matplotlib errors to do with requesting Arial font (replaced with DejaVu Sans) and asking for "equal" aspect ratio (no longer an option in 3D, removed).